### PR TITLE
Fix DOMMatrix.transformPoint()

### DIFF
--- a/geometry-polyfill.js
+++ b/geometry-polyfill.js
@@ -653,8 +653,6 @@
     }
 
     transformPoint(point) {
-      point = new DOMPoint(point);
-
       let x = point.x;
       let y = point.y;
       let z = point.z;


### PR DESCRIPTION
Hi Jarek!

The specification does not name a copy-constructor; DOMPoint doesn't implement one, leading to a broken DOMMatrix.transformPoint().
Anyway, the intended local clone of the DOMPoint is never written to - we can just remove it.